### PR TITLE
Add SuperBosses, Cups, and AtlanticaToggle to slot data

### DIFF
--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -113,7 +113,10 @@ class KH2World(World):
                 "AutoFormLogic",
                 "LevelDepth",
                 "DonaldGoofyStatsanity",
-                "CorSkipToggle"
+                "CorSkipToggle",
+                "SuperBosses",
+                "Cups",
+                "AtlanticaToggle",
         )
         slot_data.update({
             "hitlist":                [],  # remove this after next update


### PR DESCRIPTION
A little birdie called @nephalia told me these would help out the tracker 

## What is this fixing or adding?
This adds `SuperBosses`, `Cups`, and `AtlanticaToggle` to slot data

## How was this tested?
I generated, it didn't crash

## If this makes graphical changes, please attach screenshots.
N/A